### PR TITLE
Add support for providing custom view transition animations without subclassing STPTransition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Classes/STPTransition.h
+++ b/Classes/STPTransition.h
@@ -1,15 +1,16 @@
-#import <UIKit/UIKit.h>
-
 typedef NS_ENUM(NSUInteger, STPTransitionOperation) {
     STPTransitionOperationNone = 0,
     STPTransitionOperationPushPresent,
     STPTransitionOperationPopDismiss
 };
 
+@protocol STPViewTransitionAnimation;
+
 @interface STPTransition : UIPercentDrivenInteractiveTransition <UIViewControllerAnimatedTransitioning>
 
 + (instancetype)transitionWithAnimation:(void (^)(id<UIViewControllerContextTransitioning> transitionContext))animateAdHoc;
 
+@property (nonatomic, strong) Class<STPViewTransitionAnimation> viewTransitionAnimationClass;
 @property (nonatomic, strong) STPTransition *reverseTransition;
 @property (nonatomic, assign) NSTimeInterval transitionDuration;
 @property (nonatomic, assign, getter = isInteractive) BOOL interactive;

--- a/Classes/STPTransition.m
+++ b/Classes/STPTransition.m
@@ -1,6 +1,8 @@
+
 #import "STPTransition.h"
 
 #import "STPTransitionCenter.h"
+#import "STPViewTransitionAnimation.h"
 
 @interface STPTransition ()
 
@@ -47,6 +49,21 @@
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext {
     if (self.animateAdHocInContext) {
         self.animateAdHocInContext(transitionContext);
+    } else if (self.viewTransitionAnimationClass) {
+
+        UIView *container = [transitionContext containerView];
+
+        UIViewController *fromVC = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+        UIViewController *toVC = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+
+
+        [self.viewTransitionAnimationClass transitionFromView:fromVC.view
+                                                       toView:toVC.view
+                                                 asSubviewsOf:container
+                                        usingReverseAnimation:self.reverse
+                                                 onCompletion:^(BOOL finished){
+                                                     [transitionContext completeTransition:finished];
+                                                 }];
     }
 }
 

--- a/Classes/STPViewTransitionAnimation.h
+++ b/Classes/STPViewTransitionAnimation.h
@@ -1,0 +1,9 @@
+@protocol STPViewTransitionAnimation <NSObject>
+
++ (void)transitionFromView:(UIView *)oldView
+                    toView:(UIView *)newView
+              asSubviewsOf:(UIView *)parentView
+     usingReverseAnimation:(BOOL)shouldReverseAnimation
+              onCompletion:(void (^)(BOOL finished))completion;
+
+@end


### PR DESCRIPTION
The new STPViewTransitionAnimation provide a single class method that animates a transition between two views within a parent view.

This is used by STPTransition to handle view controller transitions.

Classes that conform to this protocol can also be used for view controller transitions using custom UIViewControllerContainment.
